### PR TITLE
Fix README clone script typo and report code-health findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To run online training (N-PPAC):
 bash exp_scripts/paper_configs.sh
 ```
 
-Pre-trained GP policies using `final_clone_gp.sh` are provided in the folder `nppac/trained_gps/`.
+Pre-trained GP policies using `paper_clone_gp.sh` are provided in the folder `nppac/trained_gps/`.
 
 By default, all data will be stored in `data/`.
 


### PR DESCRIPTION
### Motivation
- Correct a user-facing README reference so instructions point to the actual available script and surface obvious runtime blockers discovered during a code-health pass.

### Description
- Update `README.md` to replace the non-existent `final_clone_gp.sh` reference with the correct `paper_clone_gp.sh` and commit the change.

### Testing
- Ran `python -m compileall -q nppac rlkit` (passed); attempted `python nppac/nppac.py --help` which failed here with `ModuleNotFoundError: No module named 'gym'`; confirmed `exp_scripts/paper_clone_gp.sh` exists and `exp_scripts/final_clone_gp.sh` is missing, and used `rg` to verify README/script references.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e117229e6c83209102061e02d6376f)